### PR TITLE
[Feat] #12 - 무한 스크롤 구현

### DIFF
--- a/BookSearchProject_BY/BookSearchProject_BY/Scenes/Search/SearchView.swift
+++ b/BookSearchProject_BY/BookSearchProject_BY/Scenes/Search/SearchView.swift
@@ -48,6 +48,10 @@ final class SearchView: UIView {
         $0.dataSource = self
     }
     
+    var getCollectionView: UICollectionView {
+        collectionView
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         searchBar.delegate = self

--- a/BookSearchProject_BY/BookSearchProject_BY/Scenes/Search/SearchViewController.swift
+++ b/BookSearchProject_BY/BookSearchProject_BY/Scenes/Search/SearchViewController.swift
@@ -55,6 +55,8 @@ final class SearchViewController: UIViewController {
         super.viewDidLoad()
         setup()
         bind()
+        searchView.getCollectionView.delegate = self
+        
     }
     
     private func setup() {
@@ -157,6 +159,20 @@ extension SearchViewController: BookDetailModalDelegate {
     }
 }
 
+// 무한 스크롤 트리거
+extension SearchViewController: UICollectionViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let offsetY = scrollView.contentOffset.y
+        let contentHeight = scrollView.contentSize.height
+        let frameHeight = scrollView.frame.size.height
+        
+        // 리스트 끝에서 100pt 이내 진입 시 추가 요청
+        if offsetY > contentHeight - frameHeight - 100 {
+            searchVM.loadMoreBooksIfNeeded()
+        }
+    }
+}
+
 extension SearchView: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return SearchSection.allCases.count
@@ -205,6 +221,9 @@ extension SearchView: UICollectionViewDataSource {
             let book = searchResults[indexPath.row]
             cell.configure(with: book)
             return cell
+            
+        case .none:
+            return UICollectionViewCell()
         }
     }
     

--- a/BookSearchProject_BY/BookSearchProject_BY/ViewModel/SearchViewModel.swift
+++ b/BookSearchProject_BY/BookSearchProject_BY/ViewModel/SearchViewModel.swift
@@ -15,17 +15,36 @@ final class SearchViewModel {
     let books = BehaviorSubject(value: [Book]())
     let error = PublishSubject<Error>()
     
+    // ===== 무한 스크롤 구현을 위한 상태 변수 =====
+    private(set) var currentPage = 1
+    private(set) var isEnd = false
+    private(set) var isLoading = false
+    private var lastQuery = ""
+    
     // ===== 최근 본 책 읽기 =====
     let recentBooks = BehaviorSubject(value: [RecentBook]())
     
-    func fetchBooks(query: String) {
+    // 검색 실행 (새 검색/더보기 구분)
+    func fetchBooks(query: String, page: Int = 1, isLoadMore: Bool = false) {
+        // 새 검색이면 상태 초기화
+        if !isLoadMore {
+            currentPage = 1
+            isEnd = false
+            lastQuery = query
+        }
+        // 로딩 중이면 중복 요청 방지
+        guard !isLoading else { return }
+        isLoading = true
+        
         // 검색어를 URL에 쓸 수 있도록 인코딩 (한글도 가능하도록 안전하게)
         guard let queryEncoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
             error.onNext(NetworkError.invalidUrl)
+            isLoading = false
             return
         }
         
-        let url = "https://dapi.kakao.com/v3/search/book?query=\(queryEncoded)"
+        // page 파라미터 추가(무한 스크롤)
+        let url = "https://dapi.kakao.com/v3/search/book?query=\(queryEncoded)&page=\(page)"
         
         let headers: HTTPHeaders = [
             "Authorization": "KakaoAK \(apiKey)"
@@ -33,10 +52,25 @@ final class SearchViewModel {
         
         NetworkManager.shared.fetch(url: url, headers: headers)
             .subscribe(onSuccess: { [weak self] (response: BookResponse) in
-                self?.books.onNext(response.documents)
-            }, onFailure: {[weak self] error in
+                self?.isLoading = false
+                self?.isEnd = response.meta.isEnd
+                
+                // 성공적으로 불러 왔을 때만 페이지 증가, 새 검색은 1로 초기화
+                if isLoadMore {
+                    // 기존 데이터에 append
+                    let prev = (try? self?.books.value()) ?? []
+                    self?.books.onNext(prev + response.documents)
+                    self?.currentPage += 1
+                } else {
+                    // 새 검색이면 덮어쓰기
+                    self?.books.onNext(response.documents)
+                    self?.currentPage = 1
+                }
+            }, onFailure: { [weak self] error in
+                self?.isLoading = false
                 self?.error.onNext(error)
-            }) .disposed(by: disposeBag)
+            })
+            .disposed(by: disposeBag)
     }
     
     // ===== 최근 본 책 읽기 =====
@@ -44,5 +78,10 @@ final class SearchViewModel {
         let books = RecentBookManager.shared.fetchAllBooks()
         recentBooks.onNext(books)
     }
-
+    
+    // 무한 스크롤 트리거 함수 (마지막 페이지거나 로딩 중이면 무시)
+    func loadMoreBooksIfNeeded() {
+        guard !isEnd, !isLoading, !lastQuery.isEmpty else { return }
+        fetchBooks(query: lastQuery, page: currentPage + 1, isLoadMore: true)
+    }
 }


### PR DESCRIPTION
<!-- 
커밋 컨벤션 종류
타입      설명
Setting   파일 및 폴더 추가
Feat      새로운 기능 추가
Fix       버그 수정
Docs      문서 수정 (README.md 등)
Style     코드 스타일 변경 (포맷팅, 세미콜론 등)
Refactor  코드 리팩토링 (기능 변화 없음)
Test      테스트 코드 추가 또는 수정
Chore     빌드 설정, 패키지 매니저 설정 변경 등
Perf      성능 개선 관련 변경
-->

## 📌 PR 제목
응답 중 meta 필드 를 활용해 검색 결과 리스트에 무한 스크롤을 구현해보기

## 🔗 관련 이슈
#12

## ✍️ 작업 내용
- SearchViewController.swift
1. 검색 시 fetchBooks(query:) 호출, 첫 페이지 초기화
2. 스크롤 끝에 가까워지면 loadMoreBooksIfNeeded() 호출
- SearchViewModel.swift
1. isEnd, isLoading 체크 후 다음 페이지 fetch 새 데이터 append, currentPage 증가
2. meta.is_end로 마지막 페이지 여부 판단, isEnd=true면 추가 요청 중단

## ✅ 작업 결과
| 작업 결과 이미지 |
| :---: |
| <img src="https://github.com/user-attachments/assets/35b50dab-6f6e-45ae-983b-c5747f08f20a" width="250"> |

## 📝 추가 설명
Lv.5 완료! 키보드 설정 진행 예정
