### PR TITLE
[HotFix] - Delegate 문제로 인한 Modal 미출력 해결

### DIFF
--- a/BookSearchProject_BY/BookSearchProject_BY/Scenes/Search/SearchView.swift
+++ b/BookSearchProject_BY/BookSearchProject_BY/Scenes/Search/SearchView.swift
@@ -44,13 +44,9 @@ final class SearchView: UIView {
         $0.register(SearchEmptyStateCell.self, forCellWithReuseIdentifier: SearchEmptyStateCell.id)
         $0.register(SearchResultCell.self, forCellWithReuseIdentifier: SearchResultCell.id)
         $0.register(SectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: SectionHeaderView.id)
-        $0.delegate = self
         $0.dataSource = self
     }
     
-    var getCollectionView: UICollectionView {
-        collectionView
-    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -150,6 +146,10 @@ final class SearchView: UIView {
             make.top.equalTo(searchBar.snp.bottom).offset(15)
             make.bottom.leading.trailing.equalTo(self.safeAreaLayoutGuide)
         }
+    }
+    
+    func setCollectionViewDelegate(_ delegate: UICollectionViewDelegate) {
+        collectionView.delegate = delegate
     }
     
     // 데이터 갱신 함수


### PR DESCRIPTION
<!-- 
커밋 컨벤션 종류
타입      설명
Setting   파일 및 폴더 추가
Feat      새로운 기능 추가
Fix       버그 수정
Docs      문서 수정 (README.md 등)
Style     코드 스타일 변경 (포맷팅, 세미콜론 등)
Refactor  코드 리팩토링 (기능 변화 없음)
Test      테스트 코드 추가 또는 수정
Chore     빌드 설정, 패키지 매니저 설정 변경 등
Perf      성능 개선 관련 변경
-->

## 📌 PR 제목
Delegate 문제로 인한 Modal 미출력 해결

## 🔗 관련 이슈
#12

## ✍️ 작업 내용
setCollectionViewDelegate를 만들어  delegate를 외부에서 설정할 수 있도록 수정,
VC에서 searchView.setCollectionViewDelegate(self) 으로 호출해서 Delegate 할당
-> SearchView는 컬렉션뷰의 delegate 역할을 직접 담당하지 않고, 필요에 따라 delegate 객체를 외부에서 지정

## ✅ 작업 결과
| 작업 결과 이미지 |
| :---: |
| <img src="https://github.com/user-attachments/assets/d57558e9-8bd4-48f7-aaa5-71b638ace46e" width="250"> |

## 📝 추가 설명
ㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠ 리팩토링할 때 Delegate 한 번에 정리할거에요 ㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠ
