### PR TITLE
[HotFix] #22 - Rx로 데이터 바인딩 상태에서 빈 셀 출력되도록 수정

### DIFF
--- a/BookSearchProject_BY/BookSearchProject_BY/Domain/Entity/BookCellType.swift
+++ b/BookSearchProject_BY/BookSearchProject_BY/Domain/Entity/BookCellType.swift
@@ -1,0 +1,11 @@
+//
+//  BookCellType.swift
+//  BookSearchProject_BY
+//
+//  Created by iOS study on 5/19/25.
+//
+
+enum BookCellType {
+    case normal(Book)
+    case empty
+}

--- a/BookSearchProject_BY/BookSearchProject_BY/Presentation/ViewModel/SavedBooksViewModel.swift
+++ b/BookSearchProject_BY/BookSearchProject_BY/Presentation/ViewModel/SavedBooksViewModel.swift
@@ -15,9 +15,15 @@ final class SavedBooksViewModel {
     private let useCase: SavedBookUseCase
     private let disposeBag = DisposeBag()
     
-    // MARK: - Outputs (저장된 책 목록,  에러 메시지)
+    // MARK: - Outputs (저장된 책 목록,  에러 메시지, 데이터 스트림(빈 상태 구분)
     let books = BehaviorRelay<[Book]>(value: [])
     let showError = PublishRelay<String>()
+    var displayBooks: Observable<[BookCellType]> {
+        books
+            .map { books in
+                books.isEmpty ? [.empty] : books.map { .normal($0) }
+            }
+    }
     
     // MARK: - Initialization
     /// 뷰모델 초기화


### PR DESCRIPTION
<!-- 
커밋 컨벤션 종류
타입      설명
Setting   파일 및 폴더 추가
Feat      새로운 기능 추가
Fix       버그 수정
Docs      문서 수정 (README.md 등)
Style     코드 스타일 변경 (포맷팅, 세미콜론 등)
Refactor  코드 리팩토링 (기능 변화 없음)
Test      테스트 코드 추가 또는 수정
Chore     빌드 설정, 패키지 매니저 설정 변경 등
Perf      성능 개선 관련 변경
-->

## 📌 PR 제목
Rx로 데이터 바인딩 상태에서 빈 셀 출력되도록 수정

## 🔗 관련 이슈
#22 

## ✍️ 작업 내용
- Rx로 데이터 바인딩할 때 문제가 생겼음.
- books가 비어 있을 때는 "빈 상태용 가짜 데이터"를 넣어서 테이블뷰가 반드시 1개의 셀을 갖도록 하여 문제 해결

## ✅ 작업 결과
| 작업 결과 이미지 |
| :---: |
| <img src="https://github.com/user-attachments/assets/82b5621f-17d2-4127-9d9f-fdef8e39ec03" width="250"> |


